### PR TITLE
Add convenience method for creating new Context objects

### DIFF
--- a/log.go
+++ b/log.go
@@ -17,6 +17,14 @@ const (
 	debugContext = "debugContext"
 )
 
+// WithKey creates a new context with the provided key and value
+func WithKey(key, value string) Context {
+	return Context{
+		Key:   key,
+		Value: value,
+	}
+}
+
 // WithID creates an ID context
 func WithID(id string) Context {
 	return Context{Key: "ID", Value: id}

--- a/log_test.go
+++ b/log_test.go
@@ -53,10 +53,10 @@ func TestSubLoggers(t *testing.T) {
 	log.Error(errors.New("just an error without context"))
 	log.Debug("just a debug statement without context")
 
-	log2 := log.WithContext(dalog.Context{Key: "hello", Value: "world"})
+	log2 := log.WithContext(dalog.WithKey("hello", "world"))
 	log2.Info("we have context now!")
 
-	log3 := log2.WithContext(dalog.Context{Key: "foo", Value: "bar"})
+	log3 := log2.WithContext(dalog.WithKey("foo", "bar"))
 	log3.Info("even more context!")
 	log2.Info("but still keeps a separate context in this other logger")
 }


### PR DESCRIPTION
Using `dalog.Context{Key: ..., Value: ...}` is a little too verbose and awkward. This PR adds a method that will create a new `Context` called `WithKey`.